### PR TITLE
Adding the option to override the worldLatLngs with custom bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,20 @@ L.geoJson(data, {
 }).addTo(map);
 ```
 
+The default worldLatLngs can be overriden by passing the `worldLatLngs` attribute into the constructor.
+
+```javascript
+L.geoJson(data, {
+    invert: true,
+    worldLatLngs: [
+        L.latLng([90, 360]),
+        L.latLng([90, -180]),
+        L.latLng([-90, -180]),
+        L.latLng([-90, 360])
+    ]
+}).addTo(map);
+```
+
 
 ## License
 

--- a/src/leaflet.snogylop.js
+++ b/src/leaflet.snogylop.js
@@ -12,6 +12,8 @@
         L.extend(L.Polygon.prototype, {
 
             initialize: function (latlngs, options) {
+                worldLatlngs = (options.worldLatLngs ? options.worldLatLngs : worldLatlngs);
+
                 if (options.invert && !options.invertMultiPolygon) {
                     // Create a new set of latlngs, adding our world-sized ring
                     // first
@@ -39,6 +41,7 @@
         L.extend(L.MultiPolygon.prototype, {
 
             initialize: function (latlngs, options) {
+                worldLatlngs = (options.worldLatLngs ? options.worldLatLngs : worldLatlngs);
                 this._layers = {};
                 this._options = options;
 


### PR DESCRIPTION
This may not be the ideal solution so I'm open to other ideas! The issue occurred when reversing a polygon around New Zealand, cuts of the shading at the antimeridian (related to #2). Adding a custom area allows the polygon to cover multiple earths, and restricting the bounds and zoom level on the map sets the view so users can't venture out of the shaded area.

```javascript
 // anitmeridian support
var worldLatLngs = [
    L.latLng([90, 360]),
    L.latLng([90, -180]),
    L.latLng([-90, -180]),
    L.latLng([-90, 360])
];

// create inverse layer
var layer = L.geoJson(bounds, {
    invert: true,
    worldLatLngs: worldLatLngs
});
layer.addTo(map);

// set the max bounds and zoom
var maxBounds = L.latLngBounds(worldLatLngs[2], worldLatLngs[0]);
map.setMaxBounds(maxBounds);
map._layersMinZoom = 3;
```