### PR TITLE
Add check if options defined

### DIFF
--- a/src/leaflet.snogylop.js
+++ b/src/leaflet.snogylop.js
@@ -12,7 +12,7 @@
         L.extend(L.Polygon.prototype, {
 
             initialize: function (latlngs, options) {
-                if (options.invert && !options.invertMultiPolygon) {
+                if (options && options.invert && !options.invertMultiPolygon) {
                     // Create a new set of latlngs, adding our world-sized ring
                     // first
                     var newLatlngs = [];


### PR DESCRIPTION
Plugin throws an error
> Uncaught TypeError: Cannot read property 'invert' of undefined

when i'm trying to init any polygon without options
```coffeescript
polygon = L.polygon polygonPoints
```