### PR TITLE
Fix draw

### DIFF
--- a/src/leaflet.snogylop.js
+++ b/src/leaflet.snogylop.js
@@ -67,9 +67,9 @@
             L.extend(L.Polygon.prototype, {
 
                 _setLatLngs: function(latlngs) {
+                    this._originalLatLngs = latlngs;
                     if (this.options.invert) {
                         worldLatlngs = (this.options.worldLatLngs ? this.options.worldLatLngs : worldLatlngs);
-                        this._originalLatLngs = latlngs;
                         // Create a new set of latlngs, adding our world-sized ring
                         // first
                         var newLatlngs = [];

--- a/src/leaflet.snogylop.js
+++ b/src/leaflet.snogylop.js
@@ -68,6 +68,9 @@
 
                 _setLatLngs: function(latlngs) {
                     this._originalLatLngs = latlngs;
+                    if(L.Polyline._flat(this._originalLatLngs)) {
+                        this._originalLatLngs = [this._originalLatLngs];
+                    }
                     if (this.options.invert) {
                         worldLatlngs = (this.options.worldLatLngs ? this.options.worldLatLngs : worldLatlngs);
                         // Create a new set of latlngs, adding our world-sized ring

--- a/src/leaflet.snogylop.js
+++ b/src/leaflet.snogylop.js
@@ -65,13 +65,11 @@
         }
         else {
             L.extend(L.Polygon.prototype, {
-                initialize: function (latlngs, options) {
-                    worldLatlngs = (options.worldLatLngs ? options.worldLatLngs : worldLatlngs);
-                    this._layers = {};
-                    L.Util.setOptions(this, options);
-                    this._originalLatLngs = latlngs;
 
-                    if (options.invert) {
+                _setLatLngs: function(latlngs) {
+                    if (this.options.invert) {
+                        worldLatlngs = (this.options.worldLatLngs ? this.options.worldLatLngs : worldLatlngs);
+                        this._originalLatLngs = latlngs;
                         // Create a new set of latlngs, adding our world-sized ring
                         // first
                         var newLatlngs = [];
@@ -82,8 +80,18 @@
                         }
                         latlngs = [newLatlngs];
                     }
+                    L.Polyline.prototype._setLatLngs.call(this, latlngs);
+                    if(L.Polyline._flat(this._latlngs)) {
+                        this._latlngs = [this._latlngs];
+                    }
+                },
 
-                    this.setLatLngs(latlngs);
+                getLatLngs: function() {
+                    if (this._originalLatLngs) {
+                        // Don't return the world-sized ring, that's not helpful!
+                        return this._originalLatLngs;
+                    }
+                    return L.Polyline.prototype.getLatLngs.call(this);
                 },
 
                 getBounds: function () {


### PR DESCRIPTION
Snogylop 0.3.2 breaks Leaflet.draw (v0.4.9, Leaflet v1.0.3).  In Leaflet.draw, drawing a rectangle uses L.Rectangle.setBounds(), which uses L.Polygon._setLatLngs() after the Polygon has been initialized.  In snogylop 0.3.2, _originalLatLngs is not updated by _setLatLngs().